### PR TITLE
Require #method_tracer to make sure it's loaded before we start doing anything

### DIFF
--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -1,3 +1,5 @@
+require 'new_relic/agent/method_tracer'
+
 DependencyDetection.defer do
   @name = :rake
 


### PR DESCRIPTION
One more thing I missed.

In fact, when you install the gem and start running rake tasks, newrelic won't receive any data unless `new_relic/agent/method_tracer` is loaded, so this pull request explicitly loads it which is a good practice anyway.
