### PR TITLE
Force dispatcher and shutdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in newrelic-rake.gemspec
 gemspec
+
+group :development do
+  gem 'mocha', '~> 0.13.3'
+end

--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -21,6 +21,7 @@ DependencyDetection.defer do
         perform_action_with_newrelic_trace(:name => self.name, :category => "OtherTransaction/Rake") do
           origin_execute(args)
         end
+        NewRelic::Agent.shutdown
       end
     end
   end

--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -17,7 +17,7 @@ DependencyDetection.defer do
 
       alias_method :origin_execute, :execute
       def execute(args=nil)
-        NewRelic::Agent.manual_start
+        NewRelic::Agent.manual_start(:dispatcher => :rake)
         perform_action_with_newrelic_trace(:name => self.name, :category => "OtherTransaction/Rake") do
           origin_execute(args)
         end

--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -21,8 +21,12 @@ DependencyDetection.defer do
         perform_action_with_newrelic_trace(:name => self.name, :category => "OtherTransaction/Rake") do
           origin_execute(args)
         end
-        NewRelic::Agent.shutdown
       end
+
+      # Make sure NewRelic agent flush data to the server according to
+      # https://newrelic.com/docs/ruby/monitoring-ruby-background-processes-and-daemons
+      # even though Agent configuration is :send_data_on_exit => true
+      at_exit { NewRelic::Agent.shutdown }
     end
   end
 end

--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -30,10 +30,4 @@ class TestNewRelicRake < Test::Unit::TestCase
     Rake::Task.define_task('bar')
     Rake::Task['bar'].invoke
   end
-
-  def test_shutdown
-    NewRelic::Agent.expects(:shutdown)
-    Rake::Task.define_task('baz')
-    Rake::Task['baz'].invoke
-  end
 end

--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+require 'mocha/setup'
 require 'newrelic-rake/instrument'
 
 class TestNewRelicRake < Test::Unit::TestCase
@@ -25,8 +26,14 @@ class TestNewRelicRake < Test::Unit::TestCase
   end
 
   def test_dispatcher
+    NewRelic::Agent.expects(:manual_start).with(:dispatcher => :rake)
     Rake::Task.define_task('bar')
     Rake::Task['bar'].invoke
-    assert_equal :rake, NewRelic::Agent.config[:dispatcher]
+  end
+
+  def test_shutdown
+    NewRelic::Agent.expects(:shutdown)
+    Rake::Task.define_task('baz')
+    Rake::Task['baz'].invoke
   end
 end

--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -1,7 +1,7 @@
 require 'test/unit'
 require 'newrelic-rake/instrument'
 
-class TestNewRelicRedis < Test::Unit::TestCase
+class TestNewRelicRake < Test::Unit::TestCase
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
   def setup
@@ -22,5 +22,11 @@ class TestNewRelicRedis < Test::Unit::TestCase
     Rake::Task.define_task('foo')
     Rake::Task['foo'].invoke
     assert @engine.metrics.include?('OtherTransaction/Rake/Rake::Task/foo'), 'rake task is not in metrics'
+  end
+
+  def test_dispatcher
+    Rake::Task.define_task('bar')
+    Rake::Task['bar'].invoke
+    assert_equal :rake, NewRelic::Agent.config[:dispatcher]
   end
 end


### PR DESCRIPTION
I've been investigating why newrelic doesn't receive any data in production-like environment (it's all good in development) and it looks like
- in production we have to explicitly tell what dispatcher we want to use, can be set in two ways: by passing `:dispatcher => :rake` in `manual_start` or specifying ENV variable `NEW_RELIC_DISPATCHER=rake`
- agent has to be shut down when script finished running to send data to newrelic (according to this doc https://newrelic.com/docs/ruby/monitoring-ruby-background-processes-and-daemons)

BTW, did you try in production? Please let me know if you find any issues.
