### PR TITLE
Ignore delayed_job worker

### DIFF
--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'mocha/setup'
-require 'newrelic-rake/instrument'
+require 'newrelic-rake'
 
 class TestNewRelicRake < Test::Unit::TestCase
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation

--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -19,6 +19,12 @@ class TestNewRelicRake < Test::Unit::TestCase
     @sampler.clear_builder
   end
 
+  def test_ignore_delayed_job
+    Rake::Task.define_task('jobs:work')
+    Rake::Task['jobs:work'].invoke
+    assert !@engine.metrics.include?('OtherTransaction/Rake/Rake::Task/jobs:work'), 'jobs:work task is in metrics'
+  end
+
   def test_metrics
     Rake::Task.define_task('foo')
     Rake::Task['foo'].invoke


### PR DESCRIPTION
The delayed_job worker task normally runs via rake, but New Relic already monitors delayed_job, so there isn't really a point in having it be monitored as a rake task. This bypasses instrumentation for any task called `jobs:rake`.
