### PR TITLE
Remove explicit setting of dispatcher

### DIFF
--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -31,7 +31,7 @@ DependencyDetection.defer do
 
       def execute_with_newrelic_trace(args)
         unless ::NewRelic::Rake.started?
-          ::NewRelic::Agent.manual_start(:dispatcher => :rake)
+          ::NewRelic::Agent.manual_start
           ::NewRelic::Rake.started = true
         end
         perform_action_with_newrelic_trace(:name => self.name, :category => "OtherTransaction/Rake") do

--- a/test/newrelic_rake_test.rb
+++ b/test/newrelic_rake_test.rb
@@ -32,7 +32,7 @@ class TestNewRelicRake < Test::Unit::TestCase
   end
 
   def test_dispatcher
-    NewRelic::Agent.expects(:manual_start).with(:dispatcher => :rake)
+    NewRelic::Agent.expects(:manual_start)
     Rake::Task.define_task('bar')
     Rake::Task['bar'].invoke
   end


### PR DESCRIPTION
Older versions of `newrelic_rpm` required setting the dispatcher for the agent to report. This hasn't been the case for most of the last year, though.

Setting the dispatcher on `manual_start` wouldn't be a problem except DelayedJob (and potentially Resque) are 1) run through rake and 2) `newrelic_rpm` relies on the background framework being detected as dispatcher to function properly.

Explicitly setting the `:dispatcher => :rake` short-cuts that detection, and things break. Removing that dispatcher will only make processes on the environment page not list 'rake' preceding the hostname, which is a bummer, but
better than DJ clients missing instrumentation.

Thanks for much for maintaining this extension to New Relic! :+1: :sparkles: 
