### PR TITLE
Remove at_exit shutdown hook.

### DIFF
--- a/lib/newrelic-rake/instrument.rb
+++ b/lib/newrelic-rake/instrument.rb
@@ -24,11 +24,6 @@ DependencyDetection.defer do
         end
       end
 
-      # Make sure NewRelic agent flush data to the server according to
-      # https://newrelic.com/docs/ruby/monitoring-ruby-background-processes-and-daemons
-      # even though Agent configuration is :send_data_on_exit => true
-      at_exit { NewRelic::Agent.shutdown }
-
       def execute_with_newrelic_trace(args)
         unless ::NewRelic::Rake.started?
           ::NewRelic::Agent.manual_start


### PR DESCRIPTION
Newrelic agent already handles at_exit flushing and installing
extra at_exit handler causes bugs with ruby's exit code handling.
https://bugs.ruby-lang.org/issues/5218

This issue can be reproduced by:
- include newrelic-rake gem in your project
- run application testsuite (Rspec) that is expected to fail
  `$ rake`
- inspect exit code
  `$ echo $?`
- expected exit code should be non-zero (but is actually zero)

http://www.davekonopka.com/2013/rspec-exit-code.html
